### PR TITLE
Fixed package dependency for kafkaesque.js and produce.js in sample

### DIFF
--- a/lib/kafkaesque.js
+++ b/lib/kafkaesque.js
@@ -18,7 +18,7 @@ var assert = require('assert');
 var api = require('./api');
 var events = require('events');
 var _ = require('underscore');
-var reInterval = require('reInterval');
+var reinterval = require('reinterval');
 
 /**
  * main entry point for kafka client
@@ -738,7 +738,7 @@ module.exports = function(options) {
             console.log('error code', errorCode);
           });
 
-          _heartbeatInterval = reInterval(function heartbeat() {
+          _heartbeatInterval = reinterval(function heartbeat() {
             if (!_resyncing) {
               _groupCoordinator.heartbeat({group: _options.group, generation: _groupGeneration, memberId: _groupMemberId}, _noop);
             }

--- a/samples/produce.js
+++ b/samples/produce.js
@@ -9,14 +9,14 @@ var kafkaesque = require('../lib/kafkaesque')({brokers: [{host: 'localhost', por
 // specify the topic and partition to produce to,
 // produce the array of strings
 // callback optional
-consumer.produce({topic: 'testing', partition: 0}, ['message form 1'], function(err, res) {})
+kafkaesque.produce({topic: 'testing', partition: 0}, ['message form 1'], function(err, res) {})
 
 // specify the topic to produce to,
 // kafkaesque will choose the partition to produce to (round-robin style)
 // produce the string
-consumer.produce({topic: 'testing'}, 'message form 2')
+kafkaesque.produce({topic: 'testing'}, 'message form 2')
 
 // specify the topic to produce to,
 // kafkaesque will choose the partition to produce to (round-robin style)
 // produce the string
-consumer.produce('testing', 'message form 3')
+kafkaesque.produce('testing', 'message form 3')


### PR DESCRIPTION
Environment: 
Ubuntu 14.04

Issue: 
Cannot run the produce.js sample normally after npm install

Step to reproduce:
1 git clone https://github.com/apparatus/Kafkaesque

```
root@kafkalog:/home/sunnylearnbackend7# git clone https://github.com/apparatus/Kafkaesque
Cloning into 'Kafkaesque'...
remote: Counting objects: 600, done.
remote: Total 600 (delta 0), reused 0 (delta 0), pack-reused 600
Receiving objects: 100% (600/600), 144.52 KiB | 0 bytes/s, done.
Resolving deltas: 100% (358/358), done.
Checking connectivity... done.
```

2 cd Kafkaesque

```
root@kafkalog:/home/sunnylearnbackend7# cd Kafkaesque/
```

3 npm install

```
root@kafkalog:/home/sunnylearnbackend7/Kafkaesque# npm install
npm WARN deprecated lodash@2.2.1: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated lodash@1.0.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
npm WARN deprecated minimatch@0.4.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@2.0.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
buffer-builder@0.1.0 node_modules/buffer-builder

underscore@1.8.3 node_modules/underscore

buffer-crc32@0.2.5 node_modules/buffer-crc32

reinterval@1.1.0 node_modules/reinterval

hexy@0.2.7 node_modules/hexy

grunt-mocha-istanbul@5.0.2 node_modules/grunt-mocha-istanbul

uuid@1.4.2 node_modules/uuid

load-grunt-tasks@0.1.3 node_modules/load-grunt-tasks
├── lodash@2.2.1
└── minimatch@0.2.14 (sigmund@1.0.1, lru-cache@2.7.3)

chai@1.8.1 node_modules/chai
├── assertion-error@1.0.0
└── deep-eql@0.1.3 (type-detect@0.1.1)

grunt-mocha-test@0.7.0 node_modules/grunt-mocha-test

matchdep@0.3.0 node_modules/matchdep
├── stack-trace@0.0.7
├── resolve@0.5.1
├── globule@0.1.0 (lodash@1.0.2, minimatch@0.2.14, glob@3.1.21)
└── findup-sync@0.1.3 (lodash@2.4.2, glob@3.2.11)

grunt@0.4.5 node_modules/grunt
├── eventemitter2@0.4.14
├── dateformat@1.0.2-1.2.3
├── which@1.0.9
├── async@0.1.22
├── colors@0.6.2
├── getobject@0.1.0
├── lodash@0.9.2
├── rimraf@2.2.8
├── hooker@0.2.3
├── grunt-legacy-util@0.2.0
├── exit@0.1.2
├── nopt@1.0.10 (abbrev@1.0.9)
├── coffee-script@1.3.3
├── iconv-lite@0.2.11
├── minimatch@0.2.14 (sigmund@1.0.1, lru-cache@2.7.3)
├── underscore.string@2.2.1
├── glob@3.1.21 (inherits@1.0.2, graceful-fs@1.2.3)
├── grunt-legacy-log@0.1.3 (grunt-legacy-log-utils@0.1.1, lodash@2.4.2, underscore.string@2.3.3)
├── findup-sync@0.1.3 (lodash@2.4.2, glob@3.2.11)
└── js-yaml@2.0.5 (esprima@1.0.4, argparse@0.1.16)

mocha@1.13.0 node_modules/mocha
├── diff@1.0.7
├── growl@1.7.0
├── commander@0.6.1
├── mkdirp@0.3.5
├── debug@2.2.0 (ms@0.7.1)
├── glob@3.2.3 (inherits@2.0.1, graceful-fs@2.0.3, minimatch@0.2.14)
└── jade@0.26.3 (mkdirp@0.3.0)

grunt-contrib-jshint@0.6.5 node_modules/grunt-contrib-jshint
└── jshint@2.1.11 (console-browserify@0.1.6, underscore@1.4.4, minimatch@0.4.0, cli@0.4.5, shelljs@0.1.4)

istanbul@0.4.4 node_modules/istanbul
├── abbrev@1.0.9
├── async@1.5.2
├── wordwrap@1.0.0
├── nopt@3.0.6
├── esprima@2.7.2
├── once@1.3.3 (wrappy@1.0.2)
├── supports-color@3.1.2 (has-flag@1.0.0)
├── which@1.2.10 (isexe@1.1.2)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── fileset@0.2.1 (glob@5.0.15, minimatch@2.0.10)
├── resolve@1.1.7
├── escodegen@1.8.1 (estraverse@1.9.3, esutils@2.0.2, optionator@0.8.1, source-map@0.2.0)
├── js-yaml@3.6.1 (argparse@1.0.7)
└── handlebars@4.0.5 (source-map@0.4.4, optimist@0.6.1, uglify-js@2.7.3)
```

4 node samples/produce.js

```
root@kafkalog:/home/sunnylearnbackend7/Kafkaesque# node samples/produce.js 
module.js:327
    throw err;
    ^

Error: Cannot find module 'reInterval'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/sunnylearnbackend7/Kafkaesque/lib/kafkaesque.js:21:18)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
root@kafkalog:/home/sunnylearnbackend7/Kafkaesque# 
```

Expected result:

```
SOCKET ERROR: Error: connect ECONNREFUSED 127.0.0.1:9092
```

Actual result:

```
Error: Cannot find module 'reInterval'
    at Function.Module._resolveFilename (module.js:325:15)
    at Function.Module._load (module.js:276:25)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/sunnylearnbackend7/Kafkaesque/lib/kafkaesque.js:21:18)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
```

---

After bug fixed:
- passed `grunt build`
- `node produce.js` gives expected result:
  `SOCKET ERROR: Error: connect ECONNREFUSED 127.0.0.1:9092` (as I have not start kafka yet)

```
root@kafkalog:/home/sunnylearnbackend7# git clone https://github.com/Yermouth/Kafkaesque
Cloning into 'Kafkaesque'...
remote: Counting objects: 606, done.
remote: Compressing objects: 100% (6/6), done.
remote: Total 606 (delta 0), reused 0 (delta 0), pack-reused 600
Receiving objects: 100% (606/606), 151.97 KiB | 0 bytes/s, done.
Resolving deltas: 100% (358/358), done.
Checking connectivity... done.
root@kafkalog:/home/sunnylearnbackend7# cd Kafkaesque/
root@kafkalog:/home/sunnylearnbackend7/Kafkaesque# npm install
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated lodash@2.2.1: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated lodash@1.0.2: lodash@<3.0.0 is no longer maintained. Upgrade to lodash@^4.0.0.
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
npm WARN deprecated minimatch@0.4.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated jade@0.26.3: Jade has been renamed to pug, please install the latest version of pug instead of jade
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@2.0.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
buffer-builder@0.1.0 node_modules/buffer-builder

buffer-crc32@0.2.5 node_modules/buffer-crc32

underscore@1.8.3 node_modules/underscore

reinterval@1.1.0 node_modules/reinterval

hexy@0.2.7 node_modules/hexy

grunt-mocha-istanbul@5.0.2 node_modules/grunt-mocha-istanbul

uuid@1.4.2 node_modules/uuid

load-grunt-tasks@0.1.3 node_modules/load-grunt-tasks
├── lodash@2.2.1
└── minimatch@0.2.14 (sigmund@1.0.1, lru-cache@2.7.3)

chai@1.8.1 node_modules/chai
├── assertion-error@1.0.0
└── deep-eql@0.1.3 (type-detect@0.1.1)

grunt-mocha-test@0.7.0 node_modules/grunt-mocha-test

matchdep@0.3.0 node_modules/matchdep
├── stack-trace@0.0.7
├── resolve@0.5.1
├── globule@0.1.0 (lodash@1.0.2, minimatch@0.2.14, glob@3.1.21)
└── findup-sync@0.1.3 (lodash@2.4.2, glob@3.2.11)

mocha@1.13.0 node_modules/mocha
├── diff@1.0.7
├── growl@1.7.0
├── commander@0.6.1
├── mkdirp@0.3.5
├── debug@2.2.0 (ms@0.7.1)
├── glob@3.2.3 (inherits@2.0.1, graceful-fs@2.0.3, minimatch@0.2.14)
└── jade@0.26.3 (mkdirp@0.3.0)

grunt@0.4.5 node_modules/grunt
├── eventemitter2@0.4.14
├── dateformat@1.0.2-1.2.3
├── which@1.0.9
├── async@0.1.22
├── colors@0.6.2
├── getobject@0.1.0
├── lodash@0.9.2
├── rimraf@2.2.8
├── hooker@0.2.3
├── grunt-legacy-util@0.2.0
├── exit@0.1.2
├── nopt@1.0.10 (abbrev@1.0.9)
├── coffee-script@1.3.3
├── iconv-lite@0.2.11
├── minimatch@0.2.14 (sigmund@1.0.1, lru-cache@2.7.3)
├── underscore.string@2.2.1
├── glob@3.1.21 (inherits@1.0.2, graceful-fs@1.2.3)
├── grunt-legacy-log@0.1.3 (grunt-legacy-log-utils@0.1.1, lodash@2.4.2, underscore.string@2.3.3)
├── findup-sync@0.1.3 (lodash@2.4.2, glob@3.2.11)
└── js-yaml@2.0.5 (esprima@1.0.4, argparse@0.1.16)

grunt-contrib-jshint@0.6.5 node_modules/grunt-contrib-jshint
└── jshint@2.1.11 (console-browserify@0.1.6, underscore@1.4.4, minimatch@0.4.0, cli@0.4.5, shelljs@0.1.4)

istanbul@0.4.4 node_modules/istanbul
├── abbrev@1.0.9
├── async@1.5.2
├── wordwrap@1.0.0
├── nopt@3.0.6
├── esprima@2.7.2
├── once@1.3.3 (wrappy@1.0.2)
├── supports-color@3.1.2 (has-flag@1.0.0)
├── which@1.2.10 (isexe@1.1.2)
├── mkdirp@0.5.1 (minimist@0.0.8)
├── fileset@0.2.1 (glob@5.0.15, minimatch@2.0.10)
├── resolve@1.1.7
├── escodegen@1.8.1 (estraverse@1.9.3, esutils@2.0.2, optionator@0.8.1, source-map@0.2.0)
├── js-yaml@3.6.1 (argparse@1.0.7)
└── handlebars@4.0.5 (source-map@0.4.4, optimist@0.6.1, uglify-js@2.7.3)
root@kafkalog:/home/sunnylearnbackend7/Kafkaesque# grunt build
Running "jshint:all" (jshint) task
>> 11 files lint free.

Running "mochaTest:test" (mochaTest) task


  describeGroups test
    ✓ should correctly encode a describeGroup request 

  fetch test
    ✓ should correctly encode a fetch request 

  groupCoordinator test
    ✓ should correctly encode a groupCoordinator request 

  heartbeat test
    ✓ should correctly encode a heartbeat request 

  joinGroup test
    ✓ should correctly encode a joinGroup request with no subscriptions 
    ✓ should correctly encode a joinGroup request with subscriptions 

  leaveGroup test
    ✓ should correctly encode a leaveGroup request 

  listGroups test
    ✓ should correctly encode a listGroups request 

  metadata test
    ✓ should correclty encode a metadata request with a single topic 
    ✓ should correclty encode a metadata request with multiple topics 
    ✓ should correclty encode and envelope metadata request 

  offsetCommit test
    ✓ should correctly encode a offsetCommit request 

  offsetFetch test
    ✓ should correctly encode a offsetFetch request for fetching offset from zookeeper 
    ✓ should correctly encode a offsetFetch request for fetching offset from coordinator 
  produce test
    ✓ should correctly encode a produce request 
    ✓ should correclty encode a produce request with a single string 
  syncGroup test
    ✓ should correctly encode a syncGroup request with empty assignments 
    ✓ should correctly encode a syncGroup request with assignments 
  18 passing (37ms)
Running "mocha_istanbul:coverage" (mocha_istanbul) task
  ․․․․․․․․․․․․․․․․․․
  18 passing (30ms)
=============================================================================
Writing coverage object [/home/sunnylearnbackend7/Kafkaesque/coverage/coverage.json]
Writing coverage reports at [/home/sunnylearnbackend7/Kafkaesque/coverage]
=============================================================================
=============================== Coverage summary ===============================
Statements   : 94.57% ( 261/276 )
Branches     : 86.36% ( 19/22 )
Functions    : 91.23% ( 52/57 )
Lines        : 94.57% ( 261/276 )
================================================================================
>> Done. Check coverage folder.
Done, without errors.
root@kafkalog:/home/sunnylearnbackend7/Kafkaesque/samples# node produce.js 
SOCKET ERROR: Error: connect ECONNREFUSED 127.0.0.1:9092
```

Please let me know if there are any problems related to this request. Thank you.
